### PR TITLE
Refactor Workspaces:

### DIFF
--- a/src/Data.tsx
+++ b/src/Data.tsx
@@ -13,7 +13,6 @@ import { RelayInformation } from "nostr-tools/lib/types/nip11";
 import {
   KIND_KNOWLEDGE_NODE,
   KIND_CONTACTLIST,
-  KIND_WORKSPACES,
   KIND_VIEWS,
   KIND_SETTINGS,
   KIND_DELETE,
@@ -48,8 +47,7 @@ type ProcessedEvents = {
   relays: Relays;
 
   views: Views;
-  workspaces: List<ID>;
-  activeWorkspace: LongID | undefined;
+  workspaces: Map<ID, Workspace>;
   projectMembers: Members;
 };
 
@@ -60,40 +58,22 @@ export function newProcessedEvents(): ProcessedEvents {
     contacts: Map<PublicKey, Contact>(),
     relays: [],
     views: Map<string, View>(),
-    activeWorkspace: undefined,
-    workspaces: List<ID>(),
+    workspaces: Map<ID, Workspace>(),
     projectMembers: Map<PublicKey, Member>(),
   };
 }
 
 export const KIND_SEARCH = [KIND_KNOWLEDGE_NODE, KIND_DELETE, KIND_PROJECT];
 
-export const KINDS_META = [
-  KIND_SETTINGS,
-  KIND_CONTACTLIST,
-  KIND_WORKSPACES,
-  KIND_VIEWS,
-];
+export const KINDS_META = [KIND_SETTINGS, KIND_CONTACTLIST, KIND_VIEWS];
 
 function mergeEvents(
   processed: ProcessedEvents,
   events: List<UnsignedEvent | Event>
 ): ProcessedEvents {
-  const workspaces = findWorkspaces(events) || {
-    workspaces: List<ID>(),
-    activeWorkspace: undefined,
-  };
-
-  const newWorkspaces = processed.workspaces
-    .merge(workspaces.workspaces)
-    .toSet()
-    .toList();
-
   return {
     ...processed,
     contacts: processed.contacts.merge(findContacts(events)),
-    workspaces: newWorkspaces,
-    activeWorkspace: processed.activeWorkspace || workspaces.activeWorkspace,
     views: findViews(events).merge(processed.views),
   };
 }
@@ -119,8 +99,7 @@ function processEventsByAuthor(
     knowledgeDB,
     relays,
     views,
-    workspaces: workspaces ? workspaces.workspaces : List<ID>(),
-    activeWorkspace: workspaces ? workspaces.activeWorkspace : undefined,
+    workspaces,
     projectMembers,
   };
 }

--- a/src/KnowledgeDataContext.tsx
+++ b/src/KnowledgeDataContext.tsx
@@ -1,9 +1,7 @@
+import { useEffect, useState } from "react";
 import { List, Set } from "immutable";
 import { useParams } from "react-router-dom";
-import { useEffect, useState } from "react";
-import { useData } from "./DataContext";
 import { getNodeFromID } from "./ViewContext";
-import { useWorkspaceContext } from "./WorkspaceContext";
 
 export function shorten(nodeText: string): string {
   return nodeText.substr(0, 30);
@@ -37,14 +35,3 @@ export function useWorkspaceFromURL(): LongID | undefined {
 }
 
 export const DEFAULT_WS_NAME = "My first Workspace";
-
-export function useWorkspace(): string {
-  const { knowledgeDBs, user } = useData();
-  const { activeWorkspace: a } = useWorkspaceContext();
-  const activeWorkspace = useWorkspaceFromURL() || a;
-  const node = getNodeFromID(knowledgeDBs, activeWorkspace, user.publicKey);
-  if (!node) {
-    return DEFAULT_WS_NAME;
-  }
-  return node.text;
-}

--- a/src/SignIn.tsx
+++ b/src/SignIn.tsx
@@ -15,8 +15,6 @@ import { useData } from "./DataContext";
 import {
   planRewriteUnpublishedEvents,
   planRewriteWorkspaceIDs,
-  planUpdateWorkspaceIfNecessary,
-  planUpsertFallbackWorkspaceIfNecessary,
   usePlanner,
 } from "./planner";
 import { execute } from "./executor";
@@ -201,7 +199,6 @@ export function SignInModal(): JSX.Element {
   const { publishEventsStatus } = useData();
   const { relayPool, finalizeEvent } = useApis();
   const { createPlan, setPublishEvents } = usePlanner();
-  const isUnsavedChanges = useIsUnsavedChanges();
   const referrer = (location.state as LocationState | undefined)?.referrer;
   const onHide = (): void => {
     navigate(referrer || "/");
@@ -218,13 +215,8 @@ export function SignInModal(): JSX.Element {
     const user = withExtension
       ? loginWithExtension(key as PublicKey)
       : login(key as string);
-    const planWithNewWSIfNecessary = isUnsavedChanges
-      ? planUpsertFallbackWorkspaceIfNecessary(
-          planUpdateWorkspaceIfNecessary(createPlan())
-        )
-      : createPlan();
     const planWithRewrittenEvents = planRewriteUnpublishedEvents(
-      { ...planWithNewWSIfNecessary, user },
+      { ...createPlan(), user },
       publishEventsStatus.unsignedEvents
     );
     const plan = planRewriteWorkspaceIDs(planWithRewrittenEvents);

--- a/src/StorePreLoginContext.tsx
+++ b/src/StorePreLoginContext.tsx
@@ -2,13 +2,8 @@ import React from "react";
 import { List } from "immutable";
 import { useDebouncedCallback } from "use-debounce";
 import { useApis } from "./Apis";
-import { KIND_CONTACTLIST, KIND_VIEWS, KIND_WORKSPACES } from "./nostr";
-import {
-  planAddContacts,
-  planUpdateViews,
-  planUpdateWorkspaces,
-  usePlanner,
-} from "./planner";
+import { KIND_CONTACTLIST, KIND_VIEWS } from "./nostr";
+import { planAddContacts, planUpdateViews, usePlanner } from "./planner";
 import { execute } from "./executor";
 
 type StorePreLoginData = (eventKinds: List<number>) => void;
@@ -39,12 +34,9 @@ export function StorePreLoginContext({
         return;
       }
       const plan = createPlan();
-      const withWorkspaces = eventKinds.includes(KIND_WORKSPACES)
-        ? planUpdateWorkspaces(plan, plan.workspaces, plan.activeWorkspace)
-        : plan;
       const withViews = eventKinds.includes(KIND_VIEWS)
-        ? planUpdateViews(withWorkspaces, withWorkspaces.views)
-        : withWorkspaces;
+        ? planUpdateViews(plan, plan.views)
+        : plan;
       const withContacts = eventKinds.includes(KIND_CONTACTLIST)
         ? planAddContacts(withViews, withViews.contacts.keySeq().toList())
         : withViews;

--- a/src/WorkspaceContext.tsx
+++ b/src/WorkspaceContext.tsx
@@ -1,27 +1,56 @@
-import { List, Map, Set } from "immutable";
-import React, { createContext, useState } from "react";
+import { Map } from "immutable";
+import React, { createContext, useEffect, useState } from "react";
 import { useEventQuery } from "citadel-commons";
 import { useDefaultWorkspace } from "./NostrAuthContext";
 import { MergeKnowledgeDB, useData } from "./DataContext";
 import { useApis } from "./Apis";
-import { KIND_WORKSPACES } from "./nostr";
-import { newProcessedEvents, processEvents } from "./Data";
-import { fallbackWorkspace, replaceUnauthenticatedUser } from "./planner";
+import { KIND_DELETE, KIND_WORKSPACE } from "./nostr";
+import { processEvents } from "./Data";
+import { fallbackWorkspace, Plan, replaceUnauthenticatedUser } from "./planner";
+import { useWorkspaceFromURL } from "./KnowledgeDataContext";
 import {
-  getWorkspacesWithNodes,
-  useWorkspaceFromURL,
-} from "./KnowledgeDataContext";
-import {
-  addWorkspacesToFilter,
+  addWorkspaceNodesToFilter,
   createBaseFilter,
   filtersToFilterArray,
 } from "./dataQuery";
-import { RootViewContextProvider } from "./ViewContext";
+import { getNodeFromID, RootViewContextProvider } from "./ViewContext";
 import { useReadRelays } from "./relays";
+import { shortID, splitID } from "./connections";
+import { UNAUTHENTICATED_USER_PK } from "./AppState";
+
+function getWorkspaceFromID(
+  workspaces: Map<PublicKey, Workspaces>,
+  id: LongID,
+  myself: PublicKey
+): Workspace | undefined {
+  const [remote, wsID] = splitID(id);
+  if (!remote) {
+    return workspaces.get(myself)?.get(wsID);
+  }
+  return workspaces.get(remote)?.get(wsID);
+}
+
+export function getWorkspaceNode(
+  workspaces: Map<PublicKey, Workspaces>,
+  activeWorkspace: LongID,
+  knowledgeDBs: KnowledgeDBs,
+  user: User
+): KnowNode | undefined {
+  const workspace = getWorkspaceFromID(
+    workspaces,
+    activeWorkspace,
+    user.publicKey
+  );
+  if (!workspace) {
+    return undefined;
+  }
+  return getNodeFromID(knowledgeDBs, workspace.node, user.publicKey);
+}
 
 type WorkspaceContextType = {
   activeWorkspace: LongID;
-  workspaces: Map<PublicKey, List<ID>>;
+  workspaces: Map<PublicKey, Workspaces>;
+  setCurrentWorkspace: React.Dispatch<React.SetStateAction<LongID | undefined>>;
 };
 
 const WorkspaceContext = createContext<WorkspaceContextType | undefined>(
@@ -35,55 +64,84 @@ export function WorkspaceContextProvider({
 }): JSX.Element {
   const defaultWorkspace = useDefaultWorkspace();
   const { user, contacts, projectMembers, publishEventsStatus } = useData();
-  const { relayPool } = useApis();
+  const { relayPool, fileStore } = useApis();
   // If there is no workspace to be found, we create a new one with this ID
   const [fallbackWSID] = useState(fallbackWorkspace(user.publicKey));
-
-  const { events, eose: workspaceConfigEose } = useEventQuery(
-    relayPool,
-    [
-      {
-        authors: [user.publicKey, ...contacts.keySeq().toArray()],
-        kinds: [KIND_WORKSPACES],
-      },
-    ],
-    {
-      readFromRelays: useReadRelays({
-        user: true,
-        project: true,
-        contacts: true,
-      }),
-    }
+  const wsFromURL = useWorkspaceFromURL();
+  const [currentWorkspace, setCurrentWorkspace] = useState<LongID | undefined>(
+    wsFromURL
+      ? replaceUnauthenticatedUser(wsFromURL, user.publicKey)
+      : undefined
   );
+  const defaultWSAuthor = defaultWorkspace && splitID(defaultWorkspace)[0];
+
+  const authors = [
+    user.publicKey,
+    ...contacts.keySeq().toArray(),
+    ...(defaultWSAuthor ? [defaultWSAuthor] : []),
+  ];
+
+  const baseFilters = [
+    {
+      authors,
+      kinds: [KIND_WORKSPACE],
+    },
+    {
+      authors,
+      kinds: [KIND_DELETE],
+    },
+  ];
+  const activeWorkspace =
+    wsFromURL !== undefined
+      ? replaceUnauthenticatedUser(wsFromURL, user.publicKey)
+      : currentWorkspace ||
+        ((user.publicKey !== UNAUTHENTICATED_USER_PK &&
+          fileStore.getLocalStorage(
+            `${user.publicKey}:activeWs`
+          )) as LongID | null) ||
+        defaultWorkspace ||
+        fallbackWSID;
+
+  const authorActiveWorkspace = splitID(activeWorkspace)[0];
+  const filters = activeWorkspace
+    ? [
+        ...baseFilters,
+        {
+          ...(authorActiveWorkspace
+            ? { authors: [authorActiveWorkspace] }
+            : {}),
+          "#d": [shortID(activeWorkspace)],
+          kinds: [KIND_WORKSPACE],
+        },
+      ]
+    : baseFilters;
+
+  const { events } = useEventQuery(relayPool, filters, {
+    readFromRelays: useReadRelays({
+      user: true,
+      project: true,
+      contacts: true,
+    }),
+  });
   const workspaceEvents = events
     .valueSeq()
     .toList()
     .merge(publishEventsStatus.unsignedEvents);
   const processedEvents = processEvents(workspaceEvents);
-  const myProcessedEvents = processedEvents.get(
-    user.publicKey,
-    newProcessedEvents()
-  );
-  const wsFromURL = useWorkspaceFromURL();
-  const activeWorkspace =
-    wsFromURL !== undefined
-      ? replaceUnauthenticatedUser(wsFromURL, user.publicKey)
-      : myProcessedEvents.activeWorkspace || defaultWorkspace || fallbackWSID;
 
-  const workspaceFilters = processedEvents.reduce((rdx, p) => {
-    return addWorkspacesToFilter(rdx, p.workspaces as List<LongID>);
+  const workspaceNodesFilters = processedEvents.reduce((rdx, p) => {
+    return addWorkspaceNodesToFilter(rdx, p.workspaces);
   }, createBaseFilter(contacts, projectMembers, user.publicKey));
 
   const { events: workspaceNodesEvents } = useEventQuery(
     relayPool,
-    filtersToFilterArray(workspaceFilters),
+    filtersToFilterArray(workspaceNodesFilters),
     {
       readFromRelays: useReadRelays({
         user: true,
         project: true,
         contacts: true,
       }),
-      enabled: workspaceConfigEose,
     }
   );
   const knowledgeDBs = processEvents(
@@ -94,16 +152,30 @@ export function WorkspaceContextProvider({
   ).map((data) => data.knowledgeDB);
 
   const workspaces = processedEvents.map((p) => p.workspaces);
+  const workspace = getWorkspaceFromID(
+    workspaces,
+    activeWorkspace,
+    user.publicKey
+  );
+  useEffect(() => {
+    if (workspace && user.publicKey !== UNAUTHENTICATED_USER_PK) {
+      fileStore.setLocalStorage(`${user.publicKey}:activeWs`, workspace.id);
+    }
+  }, [workspace, user.publicKey]);
+  if (!workspace) {
+    return <div className="spinner-border" />;
+  }
 
   return (
     <WorkspaceContext.Provider
       value={{
         activeWorkspace,
         workspaces,
+        setCurrentWorkspace,
       }}
     >
       <MergeKnowledgeDB knowledgeDBs={knowledgeDBs}>
-        <RootViewContextProvider root={activeWorkspace}>
+        <RootViewContextProvider root={workspace.node}>
           {children}
         </RootViewContextProvider>
       </MergeKnowledgeDB>
@@ -121,20 +193,41 @@ export function useWorkspaceContext(): WorkspaceContextType {
   return context;
 }
 
-export function useUserWorkspaces(): List<ID> {
+export function useUserWorkspaces(): Workspaces {
   return useWorkspaceContext().workspaces.get(
     useData().user.publicKey,
-    List<ID>()
+    Map<ID, Workspace>()
   );
 }
 
-export function useWorkspaceNodes(): List<KnowNode> {
-  const { workspaces, activeWorkspace } = useWorkspaceContext();
-  const data = useData();
-  const allWorkspaces = Set<LongID | ID>(
-    workspaces.valueSeq().toList().flatten(1) as List<LongID>
-  )
-    .concat([activeWorkspace])
-    .toSet();
-  return getWorkspacesWithNodes(allWorkspaces, data);
+export function CurrentWorkspaceTitle(): JSX.Element {
+  const { knowledgeDBs, user } = useData();
+  const { activeWorkspace: activeWorkspaceID, workspaces } =
+    useWorkspaceContext();
+  const activeWorksapce = getWorkspaceFromID(
+    workspaces,
+    activeWorkspaceID,
+    user.publicKey
+  );
+  if (!activeWorksapce) {
+    return <span className="spinner-border spinner-navbar" />;
+  }
+  const node = getNodeFromID(
+    knowledgeDBs,
+    activeWorksapce.node,
+    user.publicKey
+  );
+  if (!node) {
+    return <span className="spinner-border spinner-navbar" />;
+  }
+  return <span>{node.text}</span>;
+}
+
+export function findNewActiveWorkspace(plan: Plan): LongID | undefined {
+  return plan.workspaces.reduce(
+    (rdx: LongID | undefined, workspaces): LongID | undefined => {
+      return rdx || workspaces.first()?.id;
+    },
+    undefined
+  );
 }

--- a/src/components/AddNode.test.tsx
+++ b/src/components/AddNode.test.tsx
@@ -37,7 +37,10 @@ test("Write Nodes & List on Project Relays only", async () => {
     initialRoute: `/?project=${project.id}`,
   });
   await typeNewNode(view, "Hello World");
-  const node = await findEvent(view.relayPool, KIND_KNOWLEDGE_NODE);
+  const node = await findEvent(view.relayPool, {
+    kinds: [KIND_KNOWLEDGE_NODE],
+    authors: [alice().user.publicKey],
+  });
   expect(node?.relays).toEqual(["wss://winchester.deedsats.com/"]);
 });
 
@@ -97,7 +100,7 @@ test("Default Relations are shown when adding a node from other User via search"
   });
 
   renderApp({ ...alice(), includeFocusContext: true });
-  await userEvent.type(await screen.findByText("My first Workspace"), "/");
+  await userEvent.type(await screen.findByText("Default Workspace"), "/");
   screen.getByPlaceholderText("Search");
   const searchInput = await screen.findByLabelText("search input");
   await userEvent.type(searchInput, "Object");

--- a/src/components/Column.test.tsx
+++ b/src/components/Column.test.tsx
@@ -17,7 +17,7 @@ import { newNode } from "../connections";
 import { execute } from "../executor";
 import { createPlan, planUpsertNode } from "../planner";
 import { WorkspaceView } from "./Workspace";
-import { RootViewContextProvider } from "../ViewContext";
+import { PushNode, RootViewContextProvider } from "../ViewContext";
 import { TemporaryViewProvider } from "./TemporaryViewContext";
 import { DND } from "../dnd";
 import { WorkspaceColumnView } from "./WorkspaceColumn";
@@ -79,25 +79,26 @@ test("Show Referenced By", async () => {
   const [alice] = setup([ALICE]);
   const aliceKnowledgeDB = await setupTestDB(alice(), [["Money", ["Bitcoin"]]]);
   const btc = findNodeByText(aliceKnowledgeDB, "Bitcoin") as KnowNode;
-  const db = await setupTestDB(alice(), [
-    ["Alice Workspace", [[btc], ["P2P Apps", [btc]]]],
-  ]);
-  const aliceWs = findNodeByText(db, "Alice Workspace") as KnowNode;
+  const db = await setupTestDB(
+    alice(),
+    [["Alice Workspace", [[btc], ["P2P Apps", [btc]]]]],
+    { activeWorkspace: "Alice Workspace" }
+  );
   renderWithTestData(
     <Data user={alice().user}>
       <LoadNode waitForEose>
-        <RootViewContextProvider root={aliceWs.id} indices={List([0])}>
+        <PushNode push={List([0])}>
           <TemporaryViewProvider>
             <DND>
               <WorkspaceColumnView />
             </DND>
           </TemporaryViewProvider>
-        </RootViewContextProvider>
+        </PushNode>
       </LoadNode>
     </Data>,
     {
       ...alice(),
-      initialRoute: `/w/${aliceWs.id}`,
+      initialRoute: `/w/${db.activeWorkspace}`,
     }
   );
   await screen.findByText("Bitcoin");

--- a/src/components/Follow.test.tsx
+++ b/src/components/Follow.test.tsx
@@ -228,7 +228,7 @@ test("Following in Project Context uses users relays and not projects relays", a
   const followBtn = await screen.findByLabelText("follow user");
   fireEvent.click(followBtn);
   await screen.findByText("You follow this User");
-  const event = await findEvent(relayPool, KIND_CONTACTLIST);
+  const event = await findEvent(relayPool, { kinds: [KIND_CONTACTLIST] });
   expect(event?.relays).toEqual(TEST_RELAYS.map((r) => r.url));
 });
 

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -4,15 +4,15 @@ import { useNavigate } from "react-router-dom";
 import { useMediaQuery } from "react-responsive";
 import { NotificationCenter } from "citadel-commons";
 import { SelectWorkspaces } from "./SelectWorkspaces";
-import { useWorkspace } from "../KnowledgeDataContext";
 import { IS_MOBILE } from "./responsive";
-import { DeleteNode } from "./DeleteNode";
+import { DeleteWorkspace } from "./DeleteNode";
 import { useData } from "../DataContext";
 import { planPublishSettings, usePlanner } from "../planner";
 import { PublishingStatusWrapper } from "./PublishingStatusWrapper";
 import { SignInMenuBtn } from "../SignIn";
 import { isUserLoggedIn } from "../NostrAuthContext";
 import { useProjectContext } from "../ProjectContext";
+import { CurrentWorkspaceTitle } from "../WorkspaceContext";
 
 type NavBarProps = {
   logout: () => void;
@@ -47,7 +47,6 @@ function Title(): JSX.Element | null {
   const isMobile = useMediaQuery(IS_MOBILE);
   const { projectID } = useProjectContext();
   const isProject = projectID !== undefined;
-  const title = useWorkspace();
   if (isMobile) {
     return null;
   }
@@ -56,9 +55,9 @@ function Title(): JSX.Element | null {
       <div className={`${isProject ? "bitcoin-orange" : ""} workspace-title`}>
         <Deedsats />
         <ProjectName />
-        {title}
+        <CurrentWorkspaceTitle />
       </div>
-      <DeleteNode />
+      <DeleteWorkspace />
     </div>
   );
 }
@@ -121,7 +120,7 @@ export function NavBar({ logout }: NavBarProps): JSX.Element {
               <span className="simple-icon-options-vertical" />
             </Dropdown.Toggle>
             <Dropdown.Menu>
-              <DeleteNode as="item" />
+              <DeleteWorkspace as="item" />
               <Dropdown.Item
                 className="d-flex workspace-selection"
                 onClick={() => navigate("/profile")}

--- a/src/components/Node.test.tsx
+++ b/src/components/Node.test.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import { fireEvent, screen } from "@testing-library/react";
 import { List, Map } from "immutable";
 import userEvent from "@testing-library/user-event";
-import { addRelationToRelations, newNode } from "../connections";
+import { addRelationToRelations, newNode, newWorkspace } from "../connections";
 import { DND } from "../dnd";
 import {
   ALICE,
@@ -26,6 +26,7 @@ import { Column } from "./Column";
 import { TemporaryViewProvider } from "./TemporaryViewContext";
 import {
   createPlan,
+  planAddWorkspace,
   planBulkUpsertNodes,
   planUpdateViews,
   planUpsertNode,
@@ -62,10 +63,7 @@ test("Render non existing Node", async () => {
         </DND>
       </TemporaryViewProvider>
     </RootViewContextProvider>,
-    {
-      ...alice(),
-      initialRoute: `/w/${pl.id}`,
-    }
+    alice()
   );
   await screen.findByText("Programming Languages");
   await screen.findByText("Error: Node not found");
@@ -88,10 +86,7 @@ test("Render Project", async () => {
         </DND>
       </TemporaryViewProvider>
     </RootViewContextProvider>,
-    {
-      ...alice(),
-      initialRoute: `/w/${project.id}`,
-    }
+    alice()
   );
   await screen.findByText("Winchester Mystery House");
 });
@@ -124,10 +119,7 @@ test("Edit node via Column Menu", async () => {
         </TemporaryViewProvider>
       </LoadNode>
     </RootViewContextProvider>,
-    {
-      ...alice(),
-      initialRoute: `/w/${note.id}`,
-    }
+    alice()
   );
   await expectNode("My Note", true);
   fireEvent.click(screen.getByLabelText("edit My Note"));
@@ -156,10 +148,7 @@ test("Can't edit Projects", async () => {
         </TemporaryViewProvider>
       </LoadNode>
     </RootViewContextProvider>,
-    {
-      ...alice(),
-      initialRoute: `/w/${project.id}`,
-    }
+    alice()
   );
   await expectNode("Winchester Mystery House", false);
 });
@@ -179,10 +168,7 @@ test("Load Note from other User which is not a contact", async () => {
         </TemporaryViewProvider>
       </LoadNode>
     </RootViewContextProvider>,
-    {
-      ...alice(),
-      initialRoute: `/w/${node.id}`,
-    }
+    alice()
   );
   await screen.findByText("Bobs Note");
 });
@@ -202,10 +188,7 @@ test("Cannot edit remote Note", async () => {
         </TemporaryViewProvider>
       </LoadNode>
     </RootViewContextProvider>,
-    {
-      ...alice(),
-      initialRoute: `/w/${note.id}`,
-    }
+    alice()
   );
   await expectNode("My Note", false);
 });
@@ -264,9 +247,11 @@ test("Edited node is shown in Tree View", async () => {
   const oop = newNode("Object Oriented Programming languages", publicKey);
   const java = newNode("Java", publicKey);
 
+  const ws = newWorkspace(pl.id, publicKey);
+
   const plan = planUpsertRelations(
     planUpsertRelations(
-      createPlan(alice()),
+      planAddWorkspace(createPlan(alice()), ws),
       addRelationToRelations(newRelations(pl.id, "", publicKey), oop.id)
     ),
     addRelationToRelations(newRelations(oop.id, "", publicKey), java.id)
@@ -302,7 +287,7 @@ test("Edited node is shown in Tree View", async () => {
     </LoadNode>,
     {
       ...alice(),
-      initialRoute: `/w/${pl.id}`,
+      initialRoute: `/w/${ws.id}`,
     }
   );
   fireEvent.click(await screen.findByLabelText("edit Java"));
@@ -333,10 +318,7 @@ test("Delete node", async () => {
         </DND>
       </TemporaryViewProvider>
     </RootViewContextProvider>,
-    {
-      ...alice(),
-      initialRoute: `/d/${note.id}`,
-    }
+    alice()
   );
   await screen.findByText("My Note");
   await userEvent.click(screen.getByLabelText("edit My Note"));

--- a/src/components/SearchModal.test.tsx
+++ b/src/components/SearchModal.test.tsx
@@ -20,8 +20,6 @@ import {
 import {
   createPlan,
   planBulkUpsertNodes,
-  planUpdateWorkspaceIfNecessary,
-  planUpsertFallbackWorkspaceIfNecessary,
   planUpsertMemberlist,
   planUpsertNode,
 } from "../planner";
@@ -36,14 +34,11 @@ test("Search works like spotlight", async () => {
   const thirdNote = newNode("My third search note made", publicKey);
   const topic = newNode("My very first topic", publicKey);
 
-  const planWithWS = planUpsertFallbackWorkspaceIfNecessary(
-    planUpdateWorkspaceIfNecessary(createPlan(alice()))
-  );
   await execute({
     ...alice(),
     plan: planUpsertNode(
       planUpsertNode(
-        planUpsertNode(planUpsertNode(planWithWS, note), secondNote),
+        planUpsertNode(planUpsertNode(createPlan(alice()), note), secondNote),
         thirdNote
       ),
       topic
@@ -54,7 +49,7 @@ test("Search works like spotlight", async () => {
 
   // Pressing enter adds first search result -which is a topic) to Column
   const searchButton = await screen.findByLabelText(
-    "search and attach to My first Workspace"
+    "search and attach to Default Workspace"
   );
   fireEvent.click(searchButton);
   const searchInput = await screen.findByLabelText("search input");
@@ -88,7 +83,7 @@ test("Search works like spotlight", async () => {
   await screen.findByText("My second search note ever made");
 
   const allSearchButtons = await screen.findByLabelText(
-    "search and attach to My first Workspace"
+    "search and attach to Default Workspace"
   );
   fireEvent.click(allSearchButtons);
   const searchInputField = await screen.findByLabelText("search input");
@@ -110,7 +105,7 @@ test("On Fullscreen, search also starts with press on slash key", async () => {
     ),
   });
   renderApp({ ...alice(), includeFocusContext: true });
-  await userEvent.type(await screen.findByText("My first Workspace"), "/");
+  await userEvent.type(await screen.findByText("Default Workspace"), "/");
   screen.getByPlaceholderText("Search");
   const searchInput = await screen.findByLabelText("search input");
   await userEvent.type(searchInput, "My s");

--- a/src/components/SelectWorkspaces.test.tsx
+++ b/src/components/SelectWorkspaces.test.tsx
@@ -29,12 +29,23 @@ test("Distinguish between local and remote dashboards", async () => {
   cleanup();
   renderWithTestData(<SelectWorkspaces />, alice());
   await userEvent.click(await screen.findByLabelText("switch workspace"));
+
+  await userEvent.click(switchWsBtn);
+  const newWsBtnAlice = screen.getByText("New Workspace");
+  await userEvent.click(newWsBtnAlice);
+  await userEvent.type(
+    screen.getByLabelText("title of new workspace"),
+    "Alice Workspace"
+  );
+  await userEvent.click(screen.getByText("Create Workspace"));
+
   await waitFor(() => {
     const selection = screen.getByLabelText("workspace selection");
     expectTextContent(selection, [
       "Your Workspaces",
-      "My first Workspace",
-      "Your Contacts Workspaces",
+      "Alice Workspace",
+      "Other Users Workspaces",
+      "Default Workspace",
       "Bobs Workspace",
       "New Workspace",
     ]);

--- a/src/components/TreeView.test.tsx
+++ b/src/components/TreeView.test.tsx
@@ -15,9 +15,11 @@ import { TreeView } from "./TreeView";
 
 test("Load Referenced By Nodes", async () => {
   const [alice] = setup([ALICE]);
-  const aliceDB = await setupTestDB(alice(), [
-    ["Alice Workspace", [["Money", ["Bitcoin"]]]],
-  ]);
+  const aliceDB = await setupTestDB(
+    alice(),
+    [["Alice Workspace", [["Money", ["Bitcoin"]]]]],
+    { activeWorkspace: "Alice Workspace" }
+  );
   const bitcoin = findNodeByText(aliceDB, "Bitcoin") as KnowNode;
   const aliceWs = findNodeByText(aliceDB, "Alice Workspace") as KnowNode;
 
@@ -37,7 +39,7 @@ test("Load Referenced By Nodes", async () => {
     </Data>,
     {
       ...alice(),
-      initialRoute: `/w/${aliceWs.id}`,
+      initialRoute: `/w/${aliceDB.activeWorkspace}`,
     }
   );
   await screen.findByText("Bitcoin");

--- a/src/components/Workspace.test.tsx
+++ b/src/components/Workspace.test.tsx
@@ -6,17 +6,19 @@ import {
   ANON,
   BOB,
   CAROL,
-  expectTextContent,
   findNodeByText,
-  follow,
   renderApp,
   setup,
   setupTestDB,
 } from "../utils.test";
+import { newWorkspace } from "../connections";
+import { createPlan, planAddWorkspace } from "../planner";
+import { execute } from "../executor";
 
 test("Create a new Workspace", async () => {
   const [alice] = setup([ALICE]);
   const { relayPool } = renderApp(alice());
+  const nStart = relayPool.getEvents().length;
   const switchWsBtn = await screen.findByLabelText("switch workspace");
   await userEvent.click(switchWsBtn);
   const newWsBtn = screen.getByText("New Workspace");
@@ -28,17 +30,20 @@ test("Create a new Workspace", async () => {
   await userEvent.click(screen.getByText("Create Workspace"));
   await waitFor(() => {
     // One to create the Node, one to add it to workspaces
-    expect(relayPool.getEvents()).toHaveLength(2);
+    expect(relayPool.getEvents()).toHaveLength(nStart + 2);
   });
   await screen.findAllByText("My Brand New Workspace");
   screen.getByLabelText("search and attach to My Brand New Workspace");
 });
 
-test("Load Fallback Workspace if user is not logged in", async () => {
+test("Load Default Workspace if user is not logged in", async () => {
   const [anon, bob] = setup([ANON, BOB]);
   const bobsDB = await setupTestDB(bob(), [["Bobs Workspace", ["Bitcoin"]]]);
   const wsNode = findNodeByText(bobsDB, "Bobs Workspace") as KnowNode;
-  renderApp({ ...anon(), defaultWorkspace: wsNode.id });
+  const ws = newWorkspace(wsNode.id, bob().user.publicKey);
+  const planWithWs = planAddWorkspace(createPlan(bob()), ws);
+  await execute({ ...bob(), plan: planWithWs });
+  renderApp({ ...anon(), defaultWorkspace: ws.id });
   await screen.findByText("Bobs Workspace");
   await screen.findByText("Bitcoin");
   await userEvent.click(screen.getByLabelText("switch workspace"));
@@ -46,17 +51,19 @@ test("Load Fallback Workspace if user is not logged in", async () => {
 });
 
 test("Remember active Workspace through Route changes", async () => {
-  const [anon, bob, carol, alice] = setup([ANON, BOB, CAROL, ALICE]);
-  const bobsDB = await setupTestDB(bob(), [["Bobs Workspace", ["Bitcoin"]]]);
-  const carolDB = await setupTestDB(carol(), [
-    ["Carols Workspace", ["Bitcoin"]],
-  ]);
-  const wsNode = findNodeByText(bobsDB, "Bobs Workspace") as KnowNode;
-  const defaultWs = findNodeByText(carolDB, "Carols Workspace") as KnowNode;
+  const [anon, bob, carol] = setup([ANON, BOB, CAROL]);
+  const bobsDB = await setupTestDB(bob(), [["Bobs Workspace", ["Bitcoin"]]], {
+    activeWorkspace: "Bobs Workspace",
+  });
+  const carolDB = await setupTestDB(
+    carol(),
+    [["Carols Workspace", ["Bitcoin"]]],
+    { activeWorkspace: "Carols Workspace" }
+  );
   renderApp({
     ...anon(),
-    defaultWorkspace: defaultWs.id,
-    initialRoute: `/w/${wsNode.id}`,
+    defaultWorkspace: carolDB.activeWorkspace,
+    initialRoute: `/w/${bobsDB.activeWorkspace}`,
   });
   await screen.findByText("Bobs Workspace");
   await userEvent.click(await screen.findByLabelText("sign in"));
@@ -73,15 +80,6 @@ test("Remember active Workspace through Route changes", async () => {
   expect(screen.queryByText("sign in")).toBeNull();
   await userEvent.click(screen.getByLabelText("switch workspace"));
   expect(screen.getAllByText("Bobs Workspace").length).toBe(2);
-
-  // don't remember workspace if there are no unsaved changes
-  cleanup();
-  // reload the app
-  renderApp({
-    ...alice(),
-    defaultWorkspace: defaultWs.id,
-  });
-  await screen.findByText("Carols Workspace");
 });
 
 test("Delete Workspace", async () => {
@@ -90,109 +88,33 @@ test("Delete Workspace", async () => {
   const aliceDBWithFirstWS = await setupTestDB(alice(), [["First Workspace"]], {
     activeWorkspace: "First Workspace",
   });
-  await setupTestDB(
+  const aliceDB = await setupTestDB(
     { ...alice(), ...aliceDBWithFirstWS },
     [["Bitcoin Workspace"]],
     { activeWorkspace: "Bitcoin Workspace" }
   );
   cleanup();
-  renderApp(alice());
+  renderApp({ ...alice(), defaultWorkspace: aliceDB.activeWorkspace });
   await screen.findByText("Bitcoin Workspace");
-  await userEvent.click(await screen.findByLabelText("delete node"));
+  await userEvent.click(await screen.findByLabelText("delete workspace"));
   // correct Workspace title is displayed
   await screen.findByText("First Workspace");
 });
 
-test("Can't delete the default workspace if not logged in", async () => {
+test("Can't delete the default workspace", async () => {
   const [anon, bob] = setup([ANON, BOB]);
-  const bobsDB = await setupTestDB(bob(), [["Default Workspace"]]);
-  const defaultWs = findNodeByText(bobsDB, "Default Workspace") as KnowNode;
+  const bobsDB = await setupTestDB(bob(), [["Default Workspace"]], {
+    activeWorkspace: "Default Workspace",
+  });
 
-  renderApp({ ...anon(), defaultWorkspace: defaultWs.id });
+  renderApp({ ...anon(), defaultWorkspace: bobsDB.activeWorkspace });
   await screen.findByText("Default Workspace");
   // Can't delete the default workspace if not logged in
-  expect(screen.queryByLabelText("delete node")).toBeNull();
+  expect(screen.queryByLabelText("delete workspace")).toBeNull();
+  cleanup();
 
-  // Can delete the default workspace after logged in
-  await userEvent.click(await screen.findByLabelText("sign in"));
-  await userEvent.type(
-    await screen.findByPlaceholderText(
-      "nsec, private key or mnemonic (12 words)"
-    ),
-    ALICE_PRIVATE_KEY
-  );
-  await userEvent.click(screen.getByText("Continue"));
+  // Can delete my own Workspace
+  renderApp({ ...bob(), defaultWorkspace: bobsDB.activeWorkspace });
   await screen.findByText("Default Workspace");
-  await screen.findByLabelText("delete node");
-});
-
-test("Workspace deleted by a contact is still shown", async () => {
-  const [alice, bob, carol] = setup([ALICE, BOB, CAROL]);
-  await follow(alice, bob().user.publicKey);
-  await follow(bob, alice().user.publicKey);
-  await follow(carol, alice().user.publicKey);
-  await follow(carol, bob().user.publicKey);
-
-  await setupTestDB(alice(), [["Alice Workspace"]], {
-    activeWorkspace: "Alice Workspace",
-  });
-
-  cleanup();
-  renderApp(alice());
-  await screen.findByText("Alice Workspace");
-
-  // Bob deletes Alice Workspace and can't see it anymore
-  cleanup();
-  renderApp(bob());
-  await userEvent.click(await screen.findByLabelText("switch workspace"));
-  await waitFor(() => {
-    const selection = screen.getByLabelText("workspace selection");
-    expectTextContent(selection, [
-      "Your Workspaces",
-      "My first Workspace",
-      "Your Contacts Workspaces",
-      "Alice Workspace",
-      "New Workspace",
-    ]);
-  });
-  await userEvent.click(screen.getByText("Alice Workspace"));
-  await userEvent.click(await screen.findByLabelText("delete node"));
-  await screen.findAllByText("My first Workspace");
-
-  // Carol can see Alice Workspace because neither she nor the author Alice deleted it
-  cleanup();
-  renderApp(carol());
-  await userEvent.click(await screen.findByLabelText("switch workspace"));
-  await waitFor(() => {
-    const selection = screen.getByLabelText("workspace selection");
-    expectTextContent(selection, [
-      "Your Workspaces",
-      "My first Workspace",
-      "Your Contacts Workspaces",
-      "Alice Workspace",
-      "New Workspace",
-    ]);
-  });
-
-  // Alice deletes the Workspace and can't see it anymore
-  cleanup();
-  renderApp(alice());
-  await screen.findByText("Alice Workspace");
-  await userEvent.click(await screen.findByLabelText("delete node"));
-  await screen.findAllByText("My first Workspace");
-
-  // Carol can't see Alice Workspace anymore
-  cleanup();
-  renderApp(carol());
-  await userEvent.click(await screen.findByLabelText("switch workspace"));
-  await waitFor(() => {
-    const selection = screen.getByLabelText("workspace selection");
-    expectTextContent(selection, [
-      "Your Workspaces",
-      "My first Workspace",
-      "Your Contacts Workspaces",
-      "My first Workspace",
-      "New Workspace",
-    ]);
-  });
+  await screen.findByLabelText("delete workspace");
 });

--- a/src/connections.tsx
+++ b/src/connections.tsx
@@ -306,3 +306,11 @@ export function newNode(
     imageUrl,
   };
 }
+
+export function newWorkspace(nodeId: LongID, myself: PublicKey): Workspace {
+  return {
+    id: joinID(myself, v4()),
+    node: nodeId,
+    project: undefined,
+  };
+}

--- a/src/dataQuery.tsx
+++ b/src/dataQuery.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useRef, useState } from "react";
 import { Filter } from "nostr-tools";
-import { List, Set } from "immutable";
+import { Set } from "immutable";
 import { useEventQuery } from "citadel-commons";
 import {
   KIND_DELETE,
@@ -140,15 +140,13 @@ export function addListToFilters(
   };
 }
 
-export function addWorkspaceToFilter(filters: Filters, id: LongID): Filters {
-  return addNodeToFilters(filters, id);
-}
-
-export function addWorkspacesToFilter(
+export function addWorkspaceNodesToFilter(
   filters: Filters,
-  workspaces: List<LongID>
+  workspaces: Workspaces
 ): Filters {
-  return workspaces.reduce((rdx, id) => addWorkspaceToFilter(rdx, id), filters);
+  return workspaces.reduce((rdx, workspace) => {
+    return addNodeToFilters(rdx, workspace.node);
+  }, filters);
 }
 
 export function createBaseFilter(
@@ -264,7 +262,6 @@ export function LoadNode({
       return <div className="loading" aria-label="loading" />;
     }
   }
-
   return (
     <RegisterQuery
       nodesBeeingQueried={extractNodesFromQueries(filterArray)}

--- a/src/dnd.test.tsx
+++ b/src/dnd.test.tsx
@@ -21,17 +21,19 @@ test("Dragging Source not available at Destination", async () => {
   ]);
   const btc = findNodeByText(executedPlan, "Bitcoin");
   const money = findNodeByText(executedPlan, "Money");
-  const planWithWs = await setupTestDB(alice(), [
-    ["My Workspace", [btc as KnowNode, money as KnowNode]],
-  ]);
-  const root = (findNodeByText(planWithWs, "My Workspace") as KnowNode).id;
+  const planWithWs = await setupTestDB(
+    alice(),
+    [["My Workspace", [btc as KnowNode, money as KnowNode]]],
+
+    { activeWorkspace: "My Workspace" }
+  );
   renderWithTestData(
     <LoadNode waitForEose>
       <WorkspaceView />
     </LoadNode>,
     {
       ...alice(),
-      initialRoute: `/w/${root}`,
+      initialRoute: `/w/${planWithWs.activeWorkspace}`,
     }
   );
 

--- a/src/nostr.ts
+++ b/src/nostr.ts
@@ -1,11 +1,11 @@
 export const KIND_SETTINGS = 11071;
 
 export const KIND_VIEWS = 11074;
-export const KIND_WORKSPACES = 11075;
 
 export const KIND_KNOWLEDGE_LIST = 34750;
 export const KIND_KNOWLEDGE_NODE = 34751;
 export const KIND_PROJECT = 34752;
+export const KIND_WORKSPACE = 34753;
 // Essentially a markdown which is not editable
 export const KIND_KNOWLEDGE_NODE_COLLECTION = 2945;
 

--- a/src/relays.test.tsx
+++ b/src/relays.test.tsx
@@ -82,7 +82,7 @@ test("Write Settings on user relays", async () => {
   });
   fireEvent.click(screen.getByLabelText("open menu"));
   fireEvent.click(await screen.findByLabelText("switch bionic reading on"));
-  const event = await findEvent(utils.relayPool, KIND_SETTINGS);
+  const event = await findEvent(utils.relayPool, { kinds: [KIND_SETTINGS] });
   await screen.findByLabelText("switch bionic reading off");
   expect(event?.relays).toEqual(TEST_RELAYS.map((r) => r.url));
 });
@@ -102,9 +102,9 @@ test("Write views on user relays", async () => {
   );
   utils.relayPool.resetPublishedOnRelays();
   await userEvent.click(
-    await screen.findByLabelText("increase width of My first Workspace")
+    await screen.findByLabelText("increase width of Default Workspace")
   );
-  await findEvent(utils.relayPool, KIND_VIEWS);
+  await findEvent(utils.relayPool, { kinds: [KIND_VIEWS] });
   expect(utils.relayPool.getPublishedOnRelays()).toEqual(
     TEST_RELAYS.map((r) => r.url)
   );

--- a/src/serializer.tsx
+++ b/src/serializer.tsx
@@ -212,3 +212,18 @@ export function eventToTextOrProjectNode(
   }
   return [id, { ...base, imageUrl: parseImageUrl(e) }];
 }
+
+export function eventToWorkspace(
+  e: UnsignedEvent
+): [id: string, workspace: Workspace] | [undefined] {
+  const id = findTag(e, "d");
+  if (id === undefined) {
+    return [undefined];
+  }
+  const workspace = {
+    id: joinID(e.pubkey, id),
+    node: findTag(e, "node") as LongID,
+    project: findTag(e, "project") as LongID | undefined,
+  };
+  return [id, workspace];
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -151,6 +151,13 @@ declare global {
     memberListProvider: PublicKey;
   };
 
+  type Workspace = {
+    id: LongID;
+    node: LongID;
+    project: LongID | undefined;
+  };
+  type Workspaces = Map<ID, Workspace>;
+
   type KnowNode = TextNode | ProjectNode;
 
   type Views = Map<string, View>;


### PR DESCRIPTION
- Create an own event for each workspace, to get rid of post-sign-in merge
- Store active Workspace in Browser Cache instead of writing a nostr event